### PR TITLE
Decouple CodeMashClient from GuzzleHttpClient

### DIFF
--- a/src/CodemashClient.php
+++ b/src/CodemashClient.php
@@ -1,40 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codemash;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Client\ClientInterface;
 
 class CodemashClient
 {
-    private Client $client;
+    private ClientInterface $httpClient;
+
     private array $headers;
 
-    public function __construct(string $secretKey, string $projectId)
+    public function __construct(ClientInterface $httpClient, string $secretKey, string $projectId)
     {
-        $this->client = new Client(['base_uri' => CODEMASH_API_URL]);
+        $this->httpClient = $httpClient;
         $this->headers = [
             'X-CM-ProjectId' => $projectId,
-            'Authorization' => 'Bearer ' . $secretKey,
+            'Authorization' => sprintf('Bearer %s', $secretKey),
         ];
     }
 
     /**
-     * @throws GuzzleException
      * @return array|int
      */
     public function request(string $method, string $uri, array $options = [])
     {
-        if (! empty($options['headers'])) {
-            $options['headers'] += $this->headers;
-        } else {
-            $options['headers'] = $this->headers;
-        }
+        $options['headers'] = $this->headers + ($options['headers'] ?? []);
 
-        $request = $this->client->request($method, $uri, $options);
+        $response = $this->httpClient->request($method, $uri, $options);
 
-        $statusCodeInt = (int) $request->getStatusCode();
-
-        return $statusCodeInt === 204 ? $statusCodeInt : jsonToArray((string) $request->getBody());
+        return $response->getStatusCode() === 204
+            ? $response->getStatusCode()
+            : jsonToArray((string) $response->getBody());
     }
 }

--- a/tests/CodemashClientTest.php
+++ b/tests/CodemashClientTest.php
@@ -1,35 +1,139 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests;
 
+use Codemash\CodemashClient;
+use Generator;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
 class CodemashClientTest extends TestCase
 {
-    public function testGuzzleHttpClient()
+    /**
+     * @param string $secretKey
+     * @param string $projectId
+     * @param string $method
+     * @param string $uri
+     * @param array $options
+     * @param Response $response
+     * @param array $expectedHeaders
+     * @param array|int $expectedResult
+     *
+     * @dataProvider provideTestRequest
+     */
+    public function testRequest(
+        string $secretKey,
+        string $projectId,
+        string $method,
+        string $uri,
+        array $options,
+        Response $response,
+        array $expectedHeaders,
+        $expectedResult
+    ) {
+        $mockedHttpClient = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->disableAutoReturnValueGeneration()
+            ->onlyMethods(['request'])
+            ->getMock();
+
+        $client = new CodemashClient(
+            $mockedHttpClient,
+            $secretKey,
+            $projectId
+        );
+
+        $expectedOptions = ['headers' =>  $expectedHeaders + ($options['headers'] ?? [])];
+
+        $mockedHttpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with($method, $uri, $expectedOptions)
+            ->willReturn($response);
+
+        $actualResult = $client->request($method, $uri, $options);
+
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
+    public static function provideTestRequest(): Generator
     {
-        $mock = new MockHandler([
-            new Response(200, ['X-Foo' => 'Bar'], 'Hello, World'),
-            new Response(202, ['Content-Length' => 0]),
-            new RequestException('Error Communicating with Server', new Request('GET', 'test'))
-        ]);
+        yield 'GET /dummy-uri-0 without extra headers, returns empty array' => [
+            '$secretKey' => 'dummy-secret-key-0',
+            '$projectId' => 'dummy-project-id-0',
+            '$method' => 'GET',
+            '$uri' => '/dummy-uri-0',
+            '$options' => [],
+            '$response' => new Response(200, [], '{}'),
+            '$expectedHeaders' => [
+                'X-CM-ProjectId' => 'dummy-project-id-0',
+                'Authorization' => 'Bearer dummy-secret-key-0',
+            ],
+            '$expectedResult' => [],
+        ];
 
-        $handlerStack = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handlerStack]);
+        yield 'GET /dummy-uri-1 with extra empty headers, returns empty array' => [
+            '$secretKey' => 'dummy-secret-key-1',
+            '$projectId' => 'dummy-project-id-1',
+            '$method' => 'GET',
+            '$uri' => '/dummy-uri-1',
+            '$options' => ['headers' => []],
+            '$response' => new Response(200, [], '{}'),
+            '$expectedHeaders' => [
+                'X-CM-ProjectId' => 'dummy-project-id-1',
+                'Authorization' => 'Bearer dummy-secret-key-1',
+            ],
+            '$expectedResult' => [],
+        ];
 
-        $response = $client->request('GET', '/');
-        $this->assertSame(200, $response->getStatusCode());
+        yield 'GET /dummy-uri-2 with extra dummy-header-2, returns empty array' => [
+            '$secretKey' => 'dummy-secret-key-2',
+            '$projectId' => 'dummy-project-id-2',
+            '$method' => 'GET',
+            '$uri' => '/dummy-uri-2',
+            '$options' => ['headers' => [
+                'X-Dummy-Header' => 'dummy-header-2',
+            ]],
+            '$response' => new Response(200, [], '{}'),
+            '$expectedHeaders' => [
+                'X-CM-ProjectId' => 'dummy-project-id-2',
+                'Authorization' => 'Bearer dummy-secret-key-2',
+                'X-Dummy-Header' => 'dummy-header-2',
+            ],
+            '$expectedResult' => [],
+        ];
 
-        $response = $client->request('GET', '/');
-        $this->assertSame(202, $response->getStatusCode());
+        yield 'POST /dummy-uri-3, returns dummy-value-3' => [
+            '$secretKey' => 'dummy-secret-key-3',
+            '$projectId' => 'dummy-project-id-3',
+            '$method' => 'POST',
+            '$uri' => '/dummy-uri-3',
+            '$options' => [],
+            '$response' => new Response(200, [], '{"dummy-key-3": "dummy-value-3"}'),
+            '$expectedHeaders' => [
+                'X-CM-ProjectId' => 'dummy-project-id-3',
+                'Authorization' => 'Bearer dummy-secret-key-3',
+            ],
+            '$expectedResult' => [
+                'dummy-key-3' => 'dummy-value-3'
+            ],
+        ];
 
-        $this->expectException(RequestException::class);
-        $client->request('GET', '/');
+        yield 'POST /dummy-uri-4, returns 204 code' => [
+            '$secretKey' => 'dummy-secret-key-4',
+            '$projectId' => 'dummy-project-id-4',
+            '$method' => 'POST',
+            '$uri' => '/dummy-uri-4',
+            '$options' => [],
+            '$response' => new Response(204, [], '{"dummy-key-4": "dummy-value-4"}'),
+            '$expectedHeaders' => [
+                'X-CM-ProjectId' => 'dummy-project-id-4',
+                'Authorization' => 'Bearer dummy-secret-key-4',
+            ],
+            '$expectedResult' => 204,
+        ];
     }
 }


### PR DESCRIPTION
- Requires HttpClient to be injected through the CodeMashClient constructor (dependency injection pattern)
- Adds CodeMashClient unit tests

The rationale to require HttpClient to be injected through the constructor:
1. To be able to unit-test the CodeMashClient, currently it is not possible to mock http client
2. To be able to use other available http clients that conform PSR http client interface
3. To be able to add more configuration options into http client (for example proxy)