### PR TITLE
Inject HttpClientInterface into CodeMashClient

### DIFF
--- a/examples/users.php
+++ b/examples/users.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$projectId = '';
+$secretKey = '';
+
+$httpOptions = ['base_uri' => CODEMASH_API_URL];
+
+$httpClient = new \GuzzleHttp\Client($httpOptions);
+
+$cmClient = new \Codemash\CodemashClient($secretKey, $projectId, $httpClient);
+
+$cmUser = new \Codemash\CodemashUser($cmClient);
+
+print_r($cmUser->getUsers());

--- a/src/CodemashClient.php
+++ b/src/CodemashClient.php
@@ -2,17 +2,17 @@
 
 namespace Codemash;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Client\ClientInterface;
 
 class CodemashClient
 {
-    private Client $client;
+    private ClientInterface $client;
     private array $headers;
 
-    public function __construct(string $secretKey, string $projectId)
+    public function __construct(string $secretKey, string $projectId, ClientInterface $httpClient)
     {
-        $this->client = new Client(['base_uri' => CODEMASH_API_URL]);
+        $this->client = $httpClient;
         $this->headers = [
             'X-CM-ProjectId' => $projectId,
             'Authorization' => 'Bearer ' . $secretKey,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,7 +6,7 @@ if (! function_exists('toJson')) {
      */
     function toJson($val): string
     {
-        return \GuzzleHttp\json_encode($val);
+        return is_null($val) ? '{}' : \GuzzleHttp\json_encode($val);
     }
 }
 


### PR DESCRIPTION
* Injects `Psr\Http\Client\ClientInterface` into CodeMashClient
* Adds user list endpoint consumption example
* Fixes empty(`null` json-body) encoding