### PR TITLE
Rename namespace and prefixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Codemash\\": "src/"
+      "CodeMash\\": "src/"
     },
     "files": [
       "config/config.php",

--- a/examples/membership.php
+++ b/examples/membership.php
@@ -11,8 +11,8 @@ $httpOptions = ['base_uri' => CODEMASH_API_URL];
 
 $httpClient = new \GuzzleHttp\Client($httpOptions);
 
-$cmClient = new \Codemash\Client($secretKey, $projectId, $httpClient);
+$cmClient = new \CodeMash\Client($secretKey, $projectId, $httpClient);
 
-$cmUser = new \Codemash\User($cmClient);
+$cmMembership = new \CodeMash\Membership($cmClient);
 
-print_r($cmUser->getUsers());
+print_r($cmMembership->getUsers());

--- a/examples/users.php
+++ b/examples/users.php
@@ -11,8 +11,8 @@ $httpOptions = ['base_uri' => CODEMASH_API_URL];
 
 $httpClient = new \GuzzleHttp\Client($httpOptions);
 
-$cmClient = new \Codemash\CodemashClient($secretKey, $projectId, $httpClient);
+$cmClient = new \Codemash\Client($secretKey, $projectId, $httpClient);
 
-$cmUser = new \Codemash\CodemashUser($cmClient);
+$cmUser = new \Codemash\User($cmClient);
 
 print_r($cmUser->getUsers());

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashAuthParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\AuthParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashAuth
+class Auth
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/auth/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -22,7 +22,7 @@ class CodemashAuth
      */
     public function authenticate(array $params): array
     {
-        $params = CodemashAuthParams::prepAuthenticateParams($params);
+        $params = AuthParams::prepAuthenticateParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . 'credentials', [
             'headers' => [
@@ -57,7 +57,7 @@ class CodemashAuth
      */
     public function logout(array $params): array
     {
-        $params = CodemashAuthParams::prepLogoutParams($params);
+        $params = AuthParams::prepLogoutParams($params);
 
         return $this->client->request('POST', 'auth/logout', [
             'headers' => [

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Client\ClientInterface;
 
-class CodemashClient
+class Client
 {
     private ClientInterface $client;
     private array $headers;

--- a/src/Code.php
+++ b/src/Code.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashCodeParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\CodeParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashCode
+class Code
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/serverless/functions/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -22,7 +22,7 @@ class CodemashCode
      */
     public function executeFunction(array $params): array
     {
-        $params = CodemashCodeParams::prepExecuteFunctionParams($params);
+        $params = CodeParams::prepExecuteFunctionParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . $params['id'] . '/execute', [
             'headers' => [

--- a/src/Db.php
+++ b/src/Db.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashDbParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\DbParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashDb
+class Db
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/db/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -22,7 +22,7 @@ class CodemashDb
      */
     public function insertOne(array $params): array
     {
-        $params = CodemashDbParams::prepInsertOneParams($params);
+        $params = DbParams::prepInsertOneParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . $params['collectionName'], [
             'headers' => [
@@ -41,7 +41,7 @@ class CodemashDb
      */
     public function insertMany(array $params): array
     {
-        $params = CodemashDbParams::prepInsertManyParams($params);
+        $params = DbParams::prepInsertManyParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . $params['collectionName'] . '/bulk', [
             'headers' => [
@@ -60,7 +60,7 @@ class CodemashDb
      */
     public function get(array $params): array
     {
-        $params = CodemashDbParams::prepGetParams($params);
+        $params = DbParams::prepGetParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . $params['collectionName'] . '/' . $params['id'], [
             'headers' => [
@@ -80,7 +80,7 @@ class CodemashDb
      */
     public function findOne(array $params): array
     {
-        $params = CodemashDbParams::prepFindOneParams($params);
+        $params = DbParams::prepFindOneParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . $params['collectionName'] . '/findOne', [
             'headers' => [
@@ -96,7 +96,7 @@ class CodemashDb
 
     public function findMany(array $params): array
     {
-        $params = CodemashDbParams::prepFindManyParams($params);
+        $params = DbParams::prepFindManyParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . $params['collectionName'] . '/find', [
             'headers' => [
@@ -116,7 +116,7 @@ class CodemashDb
      */
     public function count(array $params): int
     {
-        $params = CodemashDbParams::prepCountParams($params);
+        $params = DbParams::prepCountParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . $params['collectionName'] . '/count', [
             'headers' => [
@@ -135,7 +135,7 @@ class CodemashDb
      */
     public function getAggregate(array $params): array
     {
-        $params = CodemashDbParams::prepGetAggregateParams($params);
+        $params = DbParams::prepGetAggregateParams($params);
 
         $uri = ! empty($params['pipeline'])
             ? $this->uriPrefix . $params['collectionName'] . '/aggregate/pipeline'
@@ -158,7 +158,7 @@ class CodemashDb
      */
     public function replaceOne(array $params): array
     {
-        $params = CodemashDbParams::prepReplaceOneParams($params);
+        $params = DbParams::prepReplaceOneParams($params);
 
         $response = $this->client->request('PUT', $this->uriPrefix . $params['collectionName'] . '/replaceOne', [
             'headers' => [
@@ -177,7 +177,7 @@ class CodemashDb
      */
     public function updateOne(array $params): array
     {
-        $params = CodemashDbParams::prepUpdateOneParams($params);
+        $params = DbParams::prepUpdateOneParams($params);
 
         $response = $this->client->request(
             'PATCH',
@@ -200,7 +200,7 @@ class CodemashDb
      */
     public function updateOneWithFilter(array $params): array
     {
-        $params = CodemashDbParams::prepUpdateOneWithFilterParams($params);
+        $params = DbParams::prepUpdateOneWithFilterParams($params);
 
         $response = $this->client->request('PATCH', $this->uriPrefix . $params['collectionName'], [
             'headers' => [
@@ -219,7 +219,7 @@ class CodemashDb
      */
     public function updateMany(array $params): array
     {
-        $params = CodemashDbParams::prepUpdateManyParams($params);
+        $params = DbParams::prepUpdateManyParams($params);
 
         $response = $this->client->request('PATCH', $this->uriPrefix . $params['collectionName'] . '/bulk', [
             'headers' => [
@@ -238,7 +238,7 @@ class CodemashDb
      */
     public function deleteOne(array $params): array
     {
-        $params = CodemashDbParams::prepDeleteOneParams($params);
+        $params = DbParams::prepDeleteOneParams($params);
 
         $response = $this->client->request(
             'DELETE',
@@ -261,7 +261,7 @@ class CodemashDb
      */
     public function deleteOneWithFilter(array $params): array
     {
-        $params = CodemashDbParams::prepDeleteWithFilterParams($params);
+        $params = DbParams::prepDeleteWithFilterParams($params);
 
         $response = $this->client->request('DELETE', $this->uriPrefix . $params['collectionName'], [
             'headers' => [
@@ -280,7 +280,7 @@ class CodemashDb
      */
     public function deleteMany(array $params): array
     {
-        $params = CodemashDbParams::prepDeleteWithFilterParams($params);
+        $params = DbParams::prepDeleteWithFilterParams($params);
 
         $response = $this->client->request('DELETE', $this->uriPrefix . $params['collectionName'] . '/bulk', [
             'headers' => [
@@ -299,7 +299,7 @@ class CodemashDb
      */
     public function getDistinct(array $params): array
     {
-        $params = CodemashDbParams::prepGetDistinctParams($params);
+        $params = DbParams::prepGetDistinctParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . $params['collectionName'] . '/distinct', [
             'headers' => [
@@ -318,7 +318,7 @@ class CodemashDb
      */
     public function getTaxonomyTerms(array $params): array
     {
-        $params = CodemashDbParams::prepGetTaxonomyTerms($params);
+        $params = DbParams::prepGetTaxonomyTerms($params);
 
         $response = $this->client->request(
             'GET',

--- a/src/Email.php
+++ b/src/Email.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashEmailParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\EmailParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashEmail
+class Email
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -22,7 +22,7 @@ class CodemashEmail
      */
     public function send(array $params): string
     {
-        $params = CodemashEmailParams::prepSendParams($params);
+        $params = EmailParams::prepSendParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . 'notifications/email', [
             'headers' => [

--- a/src/Exceptions/RequestValidationException.php
+++ b/src/Exceptions/RequestValidationException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Codemash\Exceptions;
+namespace CodeMash\Exceptions;
 
 class RequestValidationException extends \Exception
 {

--- a/src/File.php
+++ b/src/File.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashFileParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\FileParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashFile
+class File
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -78,7 +78,7 @@ class CodemashFile
      */
     public function uploadFile(array $params): array
     {
-        $params = CodemashFileParams::prepUploadFileParams($params);
+        $params = FileParams::prepUploadFileParams($params);
 
         $options = $this->prepUploadFileOptions($params);
 
@@ -93,7 +93,7 @@ class CodemashFile
      */
     public function uploadRecordFile(array $params): array
     {
-        $params = CodemashFileParams::prepUploadRecordFileParams($params);
+        $params = FileParams::prepUploadRecordFileParams($params);
 
         $options = $this->prepUploadFileOptions($params);
 
@@ -112,7 +112,7 @@ class CodemashFile
      */
     public function uploadUserFile(array $params): array
     {
-        $params = CodemashFileParams::prepUploadUserFileParams($params);
+        $params = FileParams::prepUploadUserFileParams($params);
 
         $options = $this->prepUploadFileOptions($params);
 

--- a/src/Log.php
+++ b/src/Log.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashLogParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\LogParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashLog
+class Log
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -22,7 +22,7 @@ class CodemashLog
      */
     public function create(array $params): string
     {
-        $params = CodemashLogParams::prepCreateParams($params);
+        $params = LogParams::prepCreateParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . 'logs', [
             'headers' => [

--- a/src/Membership.php
+++ b/src/Membership.php
@@ -6,7 +6,7 @@ use CodeMash\Exceptions\RequestValidationException;
 use CodeMash\Params\UserParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class User
+class Membership
 {
     private Client $client;
     private string $uriPrefix = 'v2/membership/users/';

--- a/src/Params/AuthParams.php
+++ b/src/Params/AuthParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashAuthParams
+class AuthParams
 {
     /**
      * @throws RequestValidationException

--- a/src/Params/CodeParams.php
+++ b/src/Params/CodeParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashCodeParams
+class CodeParams
 {
     /**
      * @throws RequestValidationException

--- a/src/Params/DbParams.php
+++ b/src/Params/DbParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashDbParams
+class DbParams
 {
     /**
      * @throws RequestValidationException

--- a/src/Params/EmailParams.php
+++ b/src/Params/EmailParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashEmailParams
+class EmailParams
 {
     /**
      * @throws RequestValidationException

--- a/src/Params/FileParams.php
+++ b/src/Params/FileParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashFileParams
+class FileParams
 {
     /**
      * @throws RequestValidationException

--- a/src/Params/LogParams.php
+++ b/src/Params/LogParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashLogParams
+class LogParams
 {
     /**
      * @throws RequestValidationException

--- a/src/Params/PushNotificationParams.php
+++ b/src/Params/PushNotificationParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashPushNotificationParams
+class PushNotificationParams
 {
     /**
      * @throws RequestValidationException

--- a/src/Params/UserParams.php
+++ b/src/Params/UserParams.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Codemash\Params;
+namespace CodeMash\Params;
 
-use Codemash\Exceptions\RequestValidationException;
+use CodeMash\Exceptions\RequestValidationException;
 
-class CodemashUserParams
+class UserParams
 {
     /**
      * @throws RequestValidationException

--- a/src/PushNotification.php
+++ b/src/PushNotification.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashPushNotificationParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\PushNotificationParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashPushNotification
+class PushNotification
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/notifications/push/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -22,7 +22,7 @@ class CodemashPushNotification
      */
     public function getTemplate(array $params): array
     {
-        $params = CodemashPushNotificationParams::prepGetByIdParams($params);
+        $params = PushNotificationParams::prepGetByIdParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . 'templates/' . $params['id'], [
             'headers' => [
@@ -55,7 +55,7 @@ class CodemashPushNotification
      */
     public function sendNotification(array $params): string
     {
-        $params = CodemashPushNotificationParams::prepSendNotificationParams($params);
+        $params = PushNotificationParams::prepSendNotificationParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix, [
             'headers' => [
@@ -74,7 +74,7 @@ class CodemashPushNotification
      */
     public function getNotification(array $params): array
     {
-        $params = CodemashPushNotificationParams::prepGetByIdParams($params);
+        $params = PushNotificationParams::prepGetByIdParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . $params['id'], [
             'headers' => [
@@ -91,7 +91,7 @@ class CodemashPushNotification
      */
     public function getNotifications(array $params = []): array
     {
-        $params = CodemashPushNotificationParams::prepGetNotificationsParams($params);
+        $params = PushNotificationParams::prepGetNotificationsParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix, [
             'headers' => [
@@ -109,7 +109,7 @@ class CodemashPushNotification
      */
     public function getNotificationCount(array $params): array
     {
-        $params = CodemashPushNotificationParams::prepGetNotificationsParams($params);
+        $params = PushNotificationParams::prepGetNotificationsParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . 'count', [
             'headers' => [
@@ -128,7 +128,7 @@ class CodemashPushNotification
      */
     public function readNotification(array $params): int
     {
-        $params = CodemashPushNotificationParams::prepGetByIdParams($params);
+        $params = PushNotificationParams::prepGetByIdParams($params);
 
         return $this->client->request('PATCH', $this->uriPrefix . $params['id'] . '/read', [
             'headers' => [
@@ -144,7 +144,7 @@ class CodemashPushNotification
      */
     public function deleteNotification(array $params): int
     {
-        $params = CodemashPushNotificationParams::prepGetByIdParams($params);
+        $params = PushNotificationParams::prepGetByIdParams($params);
 
         return $this->client->request('DELETE', $this->uriPrefix . $params['id'], [
             'headers' => [
@@ -160,7 +160,7 @@ class CodemashPushNotification
      */
     public function registerDevice(array $params = []): array
     {
-        $params = CodemashPushNotificationParams::prepRegisterDeviceParams($params);
+        $params = PushNotificationParams::prepRegisterDeviceParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . 'devices', [
             'headers' => [
@@ -179,7 +179,7 @@ class CodemashPushNotification
      */
     public function registerExpoToken(array $params): string
     {
-        $params = CodemashPushNotificationParams::prepRegisterExpoTokenParams($params);
+        $params = PushNotificationParams::prepRegisterExpoTokenParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . 'token/expo', [
             'headers' => [
@@ -198,7 +198,7 @@ class CodemashPushNotification
      */
     public function getDevice(array $params): array
     {
-        $params = CodemashPushNotificationParams::prepGetByIdParams($params);
+        $params = PushNotificationParams::prepGetByIdParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . 'devices/' . $params['id'], [
             'headers' => [
@@ -231,7 +231,7 @@ class CodemashPushNotification
      */
     public function deleteDevice(array $params): int
     {
-        $params = CodemashPushNotificationParams::prepGetByIdParams($params);
+        $params = PushNotificationParams::prepGetByIdParams($params);
 
         return $this->client->request('DELETE', $this->uriPrefix . 'devices/' . $params['id'], [
             'headers' => [
@@ -247,7 +247,7 @@ class CodemashPushNotification
      */
     public function deleteDeviceToken(array $params): int
     {
-        $params = CodemashPushNotificationParams::prepGetByIdParams($params);
+        $params = PushNotificationParams::prepGetByIdParams($params);
 
         return $this->client->request('DELETE', $this->uriPrefix . 'devices/' . $params['id'] . '/token', [
             'headers' => [
@@ -263,7 +263,7 @@ class CodemashPushNotification
      */
     public function updateDeviceMeta(array $params): bool
     {
-        $params = CodemashPushNotificationParams::prepUpdateDeviceMetaParams($params);
+        $params = PushNotificationParams::prepUpdateDeviceMetaParams($params);
 
         $response = $this->client->request('PATCH', $this->uriPrefix . 'devices/' . $params['id'] . '/metadata', [
             'headers' => [
@@ -282,7 +282,7 @@ class CodemashPushNotification
      */
     public function updateDeviceTimezone(array $params): bool
     {
-        $params = CodemashPushNotificationParams::prepUpdateDeviceTimezoneParams($params);
+        $params = PushNotificationParams::prepUpdateDeviceTimezoneParams($params);
 
         $response = $this->client->request('PATCH', $this->uriPrefix . 'devices/' . $params['id'] . '/timezone', [
             'headers' => [
@@ -301,7 +301,7 @@ class CodemashPushNotification
      */
     public function updateDeviceUser(array $params): bool
     {
-        $params = CodemashPushNotificationParams::prepUpdateDeviceUserParams($params);
+        $params = PushNotificationParams::prepUpdateDeviceUserParams($params);
 
         $response = $this->client->request('PATCH', $this->uriPrefix . 'devices/' . $params['id'] . '/user', [
             'headers' => [

--- a/src/User.php
+++ b/src/User.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Codemash;
+namespace CodeMash;
 
-use Codemash\Exceptions\RequestValidationException;
-use Codemash\Params\CodemashUserParams;
+use CodeMash\Exceptions\RequestValidationException;
+use CodeMash\Params\UserParams;
 use GuzzleHttp\Exception\GuzzleException;
 
-class CodemashUser
+class User
 {
-    private CodemashClient $client;
+    private Client $client;
     private string $uriPrefix = 'v2/membership/users/';
 
-    public function __construct(CodemashClient $client)
+    public function __construct(Client $client)
     {
         $this->client = $client;
     }
@@ -22,7 +22,7 @@ class CodemashUser
      */
     public function register(array $params): array
     {
-        $params = CodemashUserParams::prepRegisterParams($params);
+        $params = UserParams::prepRegisterParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . 'register', [
             'headers' => [
@@ -41,7 +41,7 @@ class CodemashUser
      */
     public function invite(array $params): array
     {
-        $params = CodemashUserParams::prepInviteParams($params);
+        $params = UserParams::prepInviteParams($params);
 
         $response = $this->client->request('POST', $this->uriPrefix . 'invite', [
             'headers' => [
@@ -60,7 +60,7 @@ class CodemashUser
      */
     public function getUsers(?array $params = null): array
     {
-        $params = CodemashUserParams::prepGetUsersParams($params);
+        $params = UserParams::prepGetUsersParams($params);
 
         return $this->client->request('GET', $this->uriPrefix, [
             'headers' => [
@@ -77,7 +77,7 @@ class CodemashUser
      */
     public function getUser(array $params): array
     {
-        $params = CodemashUserParams::prepGetUserParams($params);
+        $params = UserParams::prepGetUserParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . $params['id'], [
             'headers' => [
@@ -96,7 +96,7 @@ class CodemashUser
      */
     public function getUserByEmail(array $params): array
     {
-        $params = CodemashUserParams::prepGetUserByEmailParams($params);
+        $params = UserParams::prepGetUserByEmailParams($params);
 
         $response = $this->client->request('GET', $this->uriPrefix . 'by-email', [
             'headers' => [
@@ -115,7 +115,7 @@ class CodemashUser
      */
     public function updateProfile(array $params): int
     {
-        $params = CodemashUserParams::prepUpdateProfileParams($params);
+        $params = UserParams::prepUpdateProfileParams($params);
 
         return $this->client->request('PATCH', $this->uriPrefix . 'profile', [
             'headers' => [
@@ -132,7 +132,7 @@ class CodemashUser
      */
     public function updateUser(array $params): int
     {
-        $params = CodemashUserParams::prepUpdateUserParams($params);
+        $params = UserParams::prepUpdateUserParams($params);
 
         return $this->client->request('PATCH', $this->uriPrefix . $params['id'], [
             'headers' => [
@@ -149,7 +149,7 @@ class CodemashUser
      */
     public function deleteUser(array $params): int
     {
-        $params = CodemashUserParams::prepOnlyIdParams($params);
+        $params = UserParams::prepOnlyIdParams($params);
 
         return $this->client->request('DELETE', $this->uriPrefix . $params['id'], [
             'headers' => [
@@ -166,7 +166,7 @@ class CodemashUser
      */
     public function blockUser(array $params): int
     {
-        $params = CodemashUserParams::prepOnlyIdParams($params);
+        $params = UserParams::prepOnlyIdParams($params);
 
         return $this->client->request('PATCH', $this->uriPrefix . $params['id'] . '/block', [
             'headers' => [
@@ -183,7 +183,7 @@ class CodemashUser
      */
     public function unblockUser(array $params): int
     {
-        $params = CodemashUserParams::prepOnlyIdParams($params);
+        $params = UserParams::prepOnlyIdParams($params);
 
         return $this->client->request('PATCH', $this->uriPrefix . $params['id'] . '/unblock', [
             'headers' => [

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -19,13 +19,13 @@ if (! function_exists('jsonToArray')) {
 
 if (! function_exists('validateRequiredRequestParams')) {
     /**
-     * @throws \Codemash\Exceptions\RequestValidationException
+     * @throws \CodeMash\Exceptions\RequestValidationException
      */
     function validateRequiredRequestParams(array $required, array $params): void
     {
         foreach ($required as $item) {
             if (empty($params[$item])) {
-                throw new \Codemash\Exceptions\RequestValidationException('"' . $item . '" is required!');
+                throw new \CodeMash\Exceptions\RequestValidationException('"' . $item . '" is required!');
             }
         }
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
-class CodemashClientTest extends TestCase
+class ClientTest extends TestCase
 {
     public function testGuzzleHttpClient()
     {


### PR DESCRIPTION
* Renamed root namespace from `Codemash` to `CodeMash` (pascal case)
* Renamed class `\CodeMash\User` (ex `\CodeMash\CodeMashUser`) to `\CodeMash\Membership` - to match service naming convention