### PR TITLE
Add code coverage reports

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: Run php unit tests
         run: composer run-script unit-tests
+
+      - name: Submit coverage report
+        run: bash <(curl -s https://codecov.io/bash)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,4 +18,12 @@
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
     </testsuites>
+    <logging>
+        <log type="coverage-clover" target="clover.xml"/>
+    </logging>
+    <filter>
+        <whitelist>
+            <directory>tests/Unit</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Adds code coverage reporting by codecod.io to the repository and PRs.

- CodeCov bot will report code coverage changes in each PR with comments
- It will allow to block PR if certain coverage criterias are not met (currently none)
- Currently enabled for unit tests, which we run on each code push

Note: since this is initial commit there is no report uploaded yet, so we will not be able to see the difference. It will be visible in upcoming PRs.